### PR TITLE
Fix environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Or install it yourself as:
 |---------------------------|------------------------|
 | `NETATMO_CLIENT_ID`       | Your app client_id     |
 | `NETATMO_CLIENT_SECRET`   | Your app client_secret |
-| `NETATMO_CLIENT_USERNAME` | User address email     |
-| `NETATMO_CLIENT_PASSWORD` | User password          |
+| `NETATMO_USERNAME`        | User address email     |
+| `NETATMO_PASSWORD`        | User password          |
 
 ### Creating a client
 


### PR DESCRIPTION
The environment variables in the `README` do not quite match the actual ones used in https://github.com/marcoroth/netatmo-ruby/blob/8149f85f24359258a5e21daf19651cb597ee5a41/lib/netatmo/client.rb#L30-L33.